### PR TITLE
Release v0.0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 # Kshow
 [![GitHub go.mod Go version of a Go module](https://img.shields.io/github/go-mod/go-version/gomods/athens.svg)](https://github.com/gomods/athens) ![GitHub release (latest by date including pre-releases)](https://img.shields.io/github/v/release/sam0392in/kshow?include_prereleases)
+[![Go Report Card](https://goreportcard.com/badge/github.com/sam0392in/kshow)](https://goreportcard.com/report/github.com/sam0392in/kshow)
+
 
 Kshow is a advanced Kubernetes CLI tool for quick access to k8s objects with custom commands.
 This project includes advanced features such as ```--show-tolerations``` , ```--detailed``` , ```resource-stats``` which existing kubernetes cli like kubectl lacks to provide.
 
 ## Current Version
-- Stable Release: 0.0.2 
-- Alpha Release: 0.0.3
+- Stable Release: 0.0.3
+- Alpha Release: 0.0.4
 
 ## Project Owners
 - Samarth Kanungo

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ mv kshow /usr/local/bin/kshow
 
 namespace is optional. Default is all namespace
 ```
-kshow get deployments --namespace <NAMESPACE>
+kshow get deployments -n <NAMESPACE>
 
 DEPLOYMENT         NAMESPACE REPLICAS    
 app-db-live        app-server   2        
@@ -49,19 +49,19 @@ app-backend-live   app-server   2
 #### **List Deployments with Tolerations**
 
 ```
-kshow get deployments --namespace <NAMESPACE> --show-tolerations
+kshow get deployments -n <NAMESPACE> --detailed
 
-DEPLOYMENT         NAMESPACE REPLICAS    TOLERATIONS
-app-db-live        app-server   2        nature-Equal-stateful-NoSchedule
-app-ui-live        app-server   1        nature-Equal-spot-NoSchedule
-app-backend-live   app-server   2 
+DEPLOYMENT         NAMESPACE  READY DISTRIBUTION    TOLERATIONS
+app-db-live        app-server  3/3   OD:0 SP:3      nature-Equal-ondemand-NoSchedule
+app-ui-live        app-server  2/2   OD:2 SP:0      nature-Equal-spot-NoSchedule
+app-backend-live   app-server  0/0   OD:0 SP:0
 ```
 
 ### Pods
 
 #### **List Pods**
 ```
-kshow get pods --namespace <NAMESPACE>
+kshow get pods -n <NAMESPACE>
 
 POD                                    READY  STATUS     RESTART  AGE   NAMESPACE
 app-db-live-54c8d4897f-clfln           1/1    Running    0        2d    app-server
@@ -100,11 +100,16 @@ ip-172-21-0-216.eu-west-1.compute.internal   Ready   3d    v1.21.5-eks-9017834
 
 ```
 kshow get nodes --detailed
+-----------------------------------------------------------------------------------------------------
+K8S-VERSION			    NODE-GROUP: NODECOUNT
+v1.21.5-eks-9017834		eks-on-demand:  1
+				        eks-spot:  9
+------------------------------------------------------------------------------------------------------
 
-NODE                                         STATUS  AGE   NODEGROUP           TENANCY    INSTANCE-TYPE  ARCH   AWS-ZONE    VERSION
-ip-172-24-0-205.eu-west-1.compute.internal   Ready   7d    spot-ng-1-21        SPOT       m4.xlarge      amd64  eu-west-1a  v1.21.5-eks-9017834
-ip-172-21-0-379.eu-west-1.compute.internal   Ready   24d   ondemand-ng-1-21    ON_DEMAND  m5a.xlarge     amd64  eu-west-1a  v1.21.5-eks-9017834
-ip-172-23-0-243.eu-west-1.compute.internal   Ready   3d    pot-1-21            SPOT       m4.xlarge      amd64  eu-west-1a  v1.21.5-eks-9017834
+NODE                                         STATUS  AGE   NODEGROUP      TENANCY    INSTANCE-TYPE  ARCH   AWS-ZONE    
+ip-172-24-0-205.eu-west-1.compute.internal   Ready   7d    eks-spot       SPOT       m4.xlarge      amd64  eu-west-1a 
+ip-172-21-0-379.eu-west-1.compute.internal   Ready   24d   eks-on-demand  ON_DEMAND  m5a.xlarge     amd64  eu-west-1c
+ip-172-23-0-243.eu-west-1.compute.internal   Ready   3d    eks-spot       SPOT       m4.xlarge      amd64  eu-west-1b
 ```
 
 
@@ -115,7 +120,7 @@ ip-172-23-0-243.eu-west-1.compute.internal   Ready   3d    pot-1-21            S
 This feature shows current CPU and Memory consumption of pods.
 
 ```
-kshow resource-stats --namespace <NAMESPACE>
+kshow resource-stats -n <NAMESPACE>
 
 NAMESPACE    POD                                  CPU   MEMORY
 app-server   app-db-live-54c8d4897f-clfln         3m    822Mi
@@ -125,7 +130,7 @@ app-server   app-backend-live-65b4d7fd57-9gcz8    23m   1457Mi
 
 #### **Get Detailed Metrics**
 ```
-kshow resource-stats --namespace <NAMESPACE> --detailed
+kshow resource-stats -n <NAMESPACE> --detailed
 
 -------------------------------------------------------------------------------------------------------
 Cluster Stats: 		Total CPU: 736 Cores		Total Memory: 1389 GB
@@ -137,4 +142,17 @@ NAMESPACE  	  POD                              CONTAINER    CURRENT-CPU  REQ-CPU
 app-server    app-db-live-54c8d4897f-clfln     app-db       2m          300m      500m       313Mi        512Mi    768Mi
 app-server    app-ui-live-54c8d4897f-glzrz     app-ui       2m          300m      500m       507Mi        12Mi     768Mi
 app-server    app-backend-live-65bfd57-9gcz8   app-backend  6m          300m      500m       1005Mi       1600Mi   1600Mi
+```
+
+#### **Get Deployment Metrics** [Alpha Feature]
+
+Below command shows cummilative CPU and Memory of all the replicas in a deployment.
+
+```
+kshow resource-stats deployments -n <NAMESPACE>
+
+DEPLOYMENT         NAMESPACE   REQ-CPU CURRENT-CPU  REQ-MEM CURRENT-MEM
+app-db-live        app-server   1800m   9m           2304Mi  2467Mi        
+app-ui-live        app-server   2000m   32m          3200Mi  2885Mi   
+app-backend-live   app-server   1000m   38m          1536Mi  1594Mi
 ```

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -33,14 +33,13 @@ var (
 
 	app = kingpin.New("kshow", "A command-line tool for kubernetes.")
 
-	get            = app.Command("get", "get details of kubernetes objects")
-	k8sObject      = get.Arg("k8s object", "allowed objects: deployment, pods").Required().String()
-	namespace      = get.Flag("namespace", "Specify namespace. default is all namespace").Short('n').Default("").String()
-	showToleration = get.Flag("show-tolerations", "show tolerations of a deloyment").Bool()
-	// Pod and Node Specific Argument
-	detailed = get.Flag("detailed", "Show extra details").Bool()
+	get       = app.Command("get", "get details of kubernetes objects")
+	k8sObject = get.Arg("k8s object", "allowed objects: deployment, pods").Required().String()
+	namespace = get.Flag("namespace", "Specify namespace. default is all namespace").Short('n').Default("").String()
+	detailed  = get.Flag("detailed", "Show extra details").Bool()
 
 	resourceStats  = app.Command("resource-stats", "Show current resource statistics")
+	statsk8sObject = resourceStats.Arg("k8s object", "allowed objects: deployment, pods").String()
 	statsNamespace = resourceStats.Flag("namespace", "Specify namespace. default is all namespace").Short('n').Default("").String()
 	statsDetailed  = resourceStats.Flag("detailed", "show detailed resource statistics").Bool()
 )
@@ -51,8 +50,8 @@ func init() {
 }
 
 func getDeployments() {
-	if *showToleration {
-		deployment.ListDeploymentwithTolerations(*namespace)
+	if *detailed {
+		deployment.ListDeploymentDetailed(*namespace)
 	} else {
 		deployment.ListDeployments(*namespace)
 	}
@@ -75,15 +74,26 @@ func getNodes() {
 }
 
 func getMetrics() {
-	if *statsDetailed {
-		metrics.PrintContainerMetrics(*statsNamespace)
-	} else {
-		metrics.PrintPodMetrics(*statsNamespace)
+	switch *statsk8sObject {
+	case "deployment", "deployments", "deploy":
+		metrics.GetDeploymentsMetrics(*statsNamespace)
+	case "pods", "pod", "po":
+		if *statsDetailed {
+			metrics.PrintContainerMetrics(*statsNamespace)
+		} else {
+			metrics.PrintPodMetrics(*statsNamespace)
+		}
+	default:
+		if *statsDetailed {
+			metrics.PrintContainerMetrics(*statsNamespace)
+		} else {
+			metrics.PrintPodMetrics(*statsNamespace)
+		}
 	}
 }
 
 func getTest() {
-	metrics.GetTotalClusterResources()
+	// node.GetNodeCountPerNG()
 }
 
 func getObject() {

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
 	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 // indirect
+	github.com/dariubs/percent v1.0.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.8.0 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -49,6 +49,8 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMn
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/dariubs/percent v1.0.0 h1:fY8q40FRYaCiFZ0gTOa73Cmp21hS32w+tSSmqbGnUzc=
+github.com/dariubs/percent v1.0.0/go.mod h1:NDZpkezJ8QqyIW/510MywB5T2KdC8v/0oTlEoPcMsRM=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
What's New?

- deployment with  `--detailed`  now has `READY`,`DISTRIBUTION` Headers. `READY` will show pod ready count VS total pod count,  `DISTRIBUTION` will show pod spread on `ON DEMAND` and `SPOTS`.

- Nodes with `--detailed` now has a new Header showing k8s version and  NodeGroup: Node Count.

- resource-stats with `--detailed` now has new Header showing `Cluster Stats `, `Namespace Stats`, `% Stats`

- resource-stats with `deployment` shows cumulative CPU and Memory of all pods in a Deployment. 